### PR TITLE
[Issue #55] fix readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.12"
+    python: "3.8"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.12"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,12 @@
 # Required
 version: 2
 
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
@@ -19,8 +25,5 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
   install:
     - requirements: docs/requirements.txt
-    - method: setuptools
-      path: .

--- a/README.rst
+++ b/README.rst
@@ -174,6 +174,14 @@ If you want to contribute, you'll need to install the dev requirements.
     $ pre-commit install
     $ pre-commit run -a
 
+To build the docs:
+
+.. code-block:: bash
+
+    $ sphinx-build -M html docs build
+
+and then open ./build/html/index.html in your browser
+
 
 ---------
 ChangeLog

--- a/dev.requirements.txt
+++ b/dev.requirements.txt
@@ -2,6 +2,6 @@ ipython
 pre-commit
 pytest
 pytest-cov
-Sphinx==3.2.1
-sphinx-rtd-theme==0.5.0
 ruff==0.8.3
+
+-r ./docs/requirements.txt

--- a/dicetables/roller.py
+++ b/dicetables/roller.py
@@ -21,8 +21,6 @@ class Roller(object):
         """
         here is
         `a nice explanation of alias tables: <http://www.keithschwarz.com/darts-dice-coins/>`_
-
-        :return: dicetables.tools.AliasTable
         """
         return self._alias_table
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,7 +19,7 @@ For some quick examples, see :doc:`the_basics`
 Contents:
 
 .. toctree::
-   :maxdepth: 3
+   :maxdepth: 2
 
    intro.rst
    the_basics.rst

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,2 @@
-#setuptools
-#Sphinx==3.2.1
-#sphinx-rtd-theme==0.5.0
-Sphinx
-sphinx-rtd-theme
+Sphinx==8.1.3
+sphinx-rtd-theme==3.0.2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-setuptools
+#setuptools
 Sphinx==3.2.1
 sphinx-rtd-theme==0.5.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,5 @@
 #setuptools
-Sphinx==3.2.1
-sphinx-rtd-theme==0.5.0
+#Sphinx==3.2.1
+#sphinx-rtd-theme==0.5.0
+Sphinx
+sphinx-rtd-theme


### PR DESCRIPTION
#55 

This fixes _very_ outdated readthedocs stuff.  it fixes how dev requirements are installed and tells how to do dev tests locally.  it also re-sets up readthedocs through some github settings and logging back into readthedocs.org