### PR TITLE
[Issue #54] make release job2

### DIFF
--- a/.github/workflows/pre-release-jobs.yaml
+++ b/.github/workflows/pre-release-jobs.yaml
@@ -30,7 +30,7 @@ jobs:
       name: pre-release-pypi
       url: https://test.pypi.org/p/dicetables
     permissions:
-      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
     steps:
       - name: Retrieve release distributions
         uses: actions/download-artifact@v4

--- a/.github/workflows/pre-release-jobs.yaml
+++ b/.github/workflows/pre-release-jobs.yaml
@@ -1,7 +1,7 @@
-name: Upload Python Package
+name: Upload Test Python Package
 on:
   release:
-    types: [released]
+    types: [prereleased]
 permissions:
   contents: read
 jobs:
@@ -23,12 +23,12 @@ jobs:
           name: release-dists
           path: dist/
   pypi-publish:
-    name: Upload release to PyPI
+    name: Upload release to Test PyPI
     runs-on: ubuntu-latest
     needs: [release-build]
     environment:
-      name: pypi
-      url: https://pypi.org/p/dicetables
+      name: testpypi
+      url: https://test.pypi.org/p/dicetables
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
@@ -39,3 +39,5 @@ jobs:
           path: dist/
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/pre-release-jobs.yaml
+++ b/.github/workflows/pre-release-jobs.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [release-build]
     environment:
-      name: testpypi
+      name: pre-release-pypi
       url: https://test.pypi.org/p/dicetables
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing

--- a/.github/workflows/release-jobs.yaml
+++ b/.github/workflows/release-jobs.yaml
@@ -23,22 +23,20 @@ jobs:
           name: release-dists
           path: dist/
   pypi-publish:
+    name: Upload release to PyPI
     runs-on: ubuntu-latest
-    needs:
-      - release-build
-    permissions:
-      # IMPORTANT: this permission is mandatory for trusted publishing
-      id-token: write
-    # Dedicated environments with protections for publishing are strongly recommended.
     environment:
-      name: pypi
-      # OPTIONAL: uncomment and update to include your PyPI project URL in the deployment status:
-      # url: https://pypi.org/p/YOURPROJECT
+      name: testpypi
+      url: https://test.pypi.org/p/dicetables
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
       - name: Retrieve release distributions
         uses: actions/download-artifact@v4
         with:
           name: release-dists
           path: dist/
-      - name: Publish release distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@6f7e8d9c0b1a2c3d4e5f6a7b8c9d0e1f2a3b4c5d
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/release-jobs.yaml
+++ b/.github/workflows/release-jobs.yaml
@@ -30,7 +30,7 @@ jobs:
       name: release-pypi
       url: https://pypi.org/p/dicetables
     permissions:
-      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
     steps:
       - name: Retrieve release distributions
         uses: actions/download-artifact@v4

--- a/.github/workflows/release-jobs.yaml
+++ b/.github/workflows/release-jobs.yaml
@@ -22,23 +22,23 @@ jobs:
         with:
           name: release-dists
           path: dist/
-#  pypi-publish:
-#    runs-on: ubuntu-latest
-#    needs:
-#      - release-build
-#    permissions:
-#      # IMPORTANT: this permission is mandatory for trusted publishing
-#      id-token: write
-#    # Dedicated environments with protections for publishing are strongly recommended.
-#    environment:
-#      name: pypi
-#      # OPTIONAL: uncomment and update to include your PyPI project URL in the deployment status:
-#      # url: https://pypi.org/p/YOURPROJECT
-#    steps:
-#      - name: Retrieve release distributions
-#        uses: actions/download-artifact@v4
-#        with:
-#          name: release-dists
-#          path: dist/
-#      - name: Publish release distributions to PyPI
-#        uses: pypa/gh-action-pypi-publish@6f7e8d9c0b1a2c3d4e5f6a7b8c9d0e1f2a3b4c5d
+  pypi-publish:
+    runs-on: ubuntu-latest
+    needs:
+      - release-build
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+    # Dedicated environments with protections for publishing are strongly recommended.
+    environment:
+      name: pypi
+      # OPTIONAL: uncomment and update to include your PyPI project URL in the deployment status:
+      # url: https://pypi.org/p/YOURPROJECT
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+      - name: Publish release distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@6f7e8d9c0b1a2c3d4e5f6a7b8c9d0e1f2a3b4c5d

--- a/.github/workflows/release-jobs.yaml
+++ b/.github/workflows/release-jobs.yaml
@@ -25,6 +25,7 @@ jobs:
   pypi-publish:
     name: Upload release to PyPI
     runs-on: ubuntu-latest
+    needs: [release-build]
     environment:
       name: testpypi
       url: https://test.pypi.org/p/dicetables

--- a/.github/workflows/release-jobs.yaml
+++ b/.github/workflows/release-jobs.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [release-build]
     environment:
-      name: pypi
+      name: release-pypi
       url: https://pypi.org/p/dicetables
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dicetables"
-version = "4.0.2"
+version = "4.0.2.post2"
 dependencies = []
 requires-python = ">=3.7"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dicetables"
-version = "4.0.2.post2"
+version = "4.0.2.post3"
 dependencies = []
 requires-python = ">=3.7"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dicetables"
-version = "4.0.2.post3"
+version = "4.0.2.post4"
 dependencies = []
 requires-python = ">=3.7"
 authors = [


### PR DESCRIPTION
#54 

This makes better release jobs.  it's real nice.  this splits up publishing based on release and pre-release.  for details see: https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=released#release