### PR TITLE
use semantic versioning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dicetables"
-version = "4.0.2.post4"
+version = "4.0.2-5"
 dependencies = []
 requires-python = ">=3.7"
 authors = [


### PR DESCRIPTION
this kind of semantic versioning gets change to 1.2.3-4 in `python -m build` gets changed to pypi's 1.2.3.post4  

https://semver.org/#spec-item-9

so using semantic versioning